### PR TITLE
Fix .only breaking duplicates

### DIFF
--- a/test/test-server.js
+++ b/test/test-server.js
@@ -231,7 +231,7 @@ describe('TodoMVC API:', () => {
       /**
        * This test requires you to add a URL to the response which has the location of the new item. 
        */
-      it('should respond with a URL which can be used to retrieve the new item', function () {
+      it('should respond with a URL which can be used to retrieve that new item', function () {
         const newItem = { title: 'Buy milk' };
         return chai.request(app)
           .post('/api/items')


### PR DESCRIPTION
With Mocha, two identically named blocks will both run if you put `.only` on one of them.

https://github.com/mochajs/mocha/issues/1060